### PR TITLE
feat: discogs parser

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,13 +16,13 @@ const fileUrlToId = (url) => {
 }
 
 const discogsUrlToId = (url) => {
-    // https://regexr.com/3i5fa
-    let discogsReleaseRegex = /([0-9]+(?:$|(?=\?)|(?=\/$)))/gm
-    let result = discogsReleaseRegex.exec(url)
-    if (!result) {
-	return undefined
-    }
-    return result[0]
+  // https://regexr.com/3i5fa
+  let discogsReleaseRegex = /([0-9]+(?:$|(?=\?)|(?=\/$)))/gm
+  let result = discogsReleaseRegex.exec(url)
+  if (!result) {
+		return undefined
+  }
+  return result[0]
 }
 
 const findId = (url, provider) => {

--- a/main.js
+++ b/main.js
@@ -15,11 +15,22 @@ const fileUrlToId = (url) => {
 	return s[s.length - 1]
 }
 
+const discogsUrlToId = (url) => {
+    // https://regexr.com/3i5fa
+    let discogsReleaseRegex = /([0-9]+(?:$|(?=\?)|(?=\/$)))/gm
+    let result = discogsReleaseRegex.exec(url)
+    if (!result) {
+	return undefined
+    }
+    return result[0]
+}
+
 const findId = (url, provider) => {
-	let methods = {
+  let methods = {
 		youtube: (url) => youtubeUrlToId(url),
-		file: (url) => fileUrlToId(url)
-	}
+		file: (url) => fileUrlToId(url),
+		discogs: (url) => discogsUrlToId(url)
+  }
 
 	let extractId = methods[provider]
 	if (typeof extractId !== 'function') {

--- a/test.js
+++ b/test.js
@@ -1,9 +1,15 @@
 import test from 'ava'
 import { mediaUrlParser } from './index.js'
 import {
-	youtubeDict,
-	fileDict
+    youtubeDict,
+    fileDict,
+    discogsDict
 } from './tests/provider-dictionaries'
+
+
+/*
+  Providers, check if they are correctly discovered in a url
+*/
 
 test('Youtube URL correctly parse the provider', t => {
 	t.plan(youtubeDict.length)
@@ -22,6 +28,20 @@ test('File URL correctly parse the provider', async t => {
 		t.is(r.provider, 'file');
 	})
 });
+
+test('Discogs URL correctly parse the provider', async t => {
+    t.plan(discogsDict.length)
+
+    discogsDict.forEach(item => {
+	let r = mediaUrlParser(item[0])
+	t.is(r.provider, 'discogs');
+    })
+});
+
+
+/*
+  ID, check if the if is found in a url of a specific provider
+*/
 
 test('Youtube URL correctly parse the id correctly', t => {
 	t.plan(youtubeDict.length)
@@ -45,4 +65,13 @@ test('It throws on invalid URL', t => {
 	const error = t.throws(() => {
 		mediaUrlParser('notanurl')
 	})
+});
+
+test('Discogs URL correctly parse the id correctly', t => {
+    t.plan(discogsDict.length)
+
+    discogsDict.forEach(item => {
+	let r = mediaUrlParser(item[0])
+	t.is(r.id, item[1]);
+    })
 });

--- a/tests/provider-dictionaries.js
+++ b/tests/provider-dictionaries.js
@@ -55,3 +55,51 @@ exports.fileDict = [
 	'Birds_Polyphonic.ogg'
     ]
 ]
+
+
+exports.discogsDict = [
+    [
+	'https://7778787987987.discogs.com/1123123/release/082112312312331',
+	'082112312312331'
+    ],
+    [
+	'https://7778787987987.discogs.com/1123123/release/082112312312331/',
+	'082112312312331'
+    ],
+    [
+	'https://www.discogs.com/Various-Absolute-99333331999/release/1607906',
+	'1607906'
+    ],
+    [
+	'https://www.discogs.com/Various-Absolute-99-The-Best-Of-1999/release/1607906',
+	'1607906'
+    ],
+    [
+	'https://www.discogs.com/Nu-Guinea-The-Tony-Allen-Experiments/release/7983975',
+	'7983975'
+    ],
+    [
+	'https://www.discogs.com/Nu-Guinea-The-Tony-Allen-Experiments/master/945635',
+	'945635'
+    ],
+    [
+	'https://www.discogs.com/Nu-Guinea-The-Tony-Allen-Experiments/release/7997305',
+	'7997305'
+    ],
+    [
+	'https://www.discogs.com/sell/release/7983975?ev=rb',
+	'7983975'
+    ],
+    [
+	'https://www.discogs.com/sell/release/7983975?offers=1&condition=Mint+%28M%29',
+	'7983975'
+    ],
+    [
+	'https://www.discogs.com/sell/release/7983975?currency=USD&condition=Mint+%2833M%29',
+	'7983975'
+    ],
+    [
+	'https://www.discogs.com/sell/release/7983975?currency=USD&condition=Mint+%28M%2932323232323',
+	'7983975'
+    ]
+]


### PR DESCRIPTION
On the same idea as `youtube` and `file`, this PR implements the `discogs` provider.

```
var result = mediaUrlParser('https://www.discogs.com/sell/release/7983975?currency=USD&condition=Mint+%2833M%29')
```
```
// result
{
  url: 'https://www.discogs.com/sell/release/7983975?currency=USD&conditio
n=Mint+%2833M%29',                                                   
  provider: 'discogs',
  id: '7983975'
}
```