### PR TITLE
Fix URL dependency

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,3 @@
-import URL from 'url'
 import youtubeRegex from 'youtube-regex'
 import providersList from './src/providers'
 
@@ -11,7 +10,7 @@ const youtubeUrlToId = (url) => {
 }
 
 const fileUrlToId = (url) => {
-    let result = URL.parse(url)
+    let result = new URL(url)
     let s = result.pathname.split('/')
     return s[s.length - 1]
 }
@@ -31,7 +30,7 @@ const findId = (url, provider) => {
 }
 
 const findProvider = (url) => {
-    let result = URL.parse(url)
+    let result = new URL(url)
     let hostId = extractHostId(result.host)
     
     // from the hostId, find the provider id 
@@ -53,7 +52,7 @@ const extractHostId = (host) => {
 
 // enforces the presence of a `host` in the url
 const normalizeUrl = (url) => {
-    let result = URL.parse(url)
+    let result = new URL(url)
     // case there is no `http://` in the url
     if(!result.hostname) {
 	// default to https

--- a/test.js
+++ b/test.js
@@ -40,3 +40,9 @@ test('File URL correctly parse the id correctly', t => {
 	t.is(r.id, item[1]);
     })
 });
+
+test('It throws on invalid URL', t => {
+	const error = t.throws(() => {
+		mediaUrlParser('notanurl')
+	})
+});

--- a/tests/provider-dictionaries.js
+++ b/tests/provider-dictionaries.js
@@ -39,7 +39,7 @@ exports.youtubeDict = [
 
 exports.fileDict = [
     [
-	'192.168.0.1/a/longer/path/podcast.ogg',
+	'http://192.168.0.1/a/longer/path/podcast.ogg',
 	'podcast.ogg'
     ],
     [


### PR DESCRIPTION
When bundling this library in a browser, it would include the full node.js shim of the browser's `URL` API (+70kb), because of our `import URL from 'url'` part.

Luckily newer node includes this by default. To use it, remove the import.

This PR removes the import and refactors the the new API. I believe this will "just work" without extra bundler configuration, like we did in r4 player.

https://developer.mozilla.org/en-US/docs/Web/API/URL
https://nodejs.org/api/url.html#url_the_whatwg_url_api