### PR TITLE
Fix/url object bug

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,7 +40,7 @@ const findId = (url, provider) => {
 }
 
 const findProvider = (url) => {
-	let hostId = extractHostId(url.host)
+	let hostId = extractHostId(new URL(url).host)
 
 	// from the hostId, find the provider id
 	// and fallback to file.
@@ -67,12 +67,12 @@ const normalizeUrl = (url) => {
 	if (!url.startsWith('http')) {
 		url = `https://${url}`
 	}
-	return new URL(url)
+	return url
 }
 
-const mediaUrlParser = (url) => {
+const mediaUrlParser = (inputUrl) => {
 	// 0. normalize url, so it can be parsed homogenously
-	url = normalizeUrl(url)
+	const url = normalizeUrl(inputUrl)
 
 	// 1. detect which provider's url it is
 	let provider = findProvider(url)

--- a/test.js
+++ b/test.js
@@ -15,6 +15,14 @@ test('Youtube URL correctly parse the provider', t => {
 	})
 })
 
+test('object returned includes a normalized url property', t => {
+	youtubeDict.forEach(item => {
+		let r = mediaUrlParser(item[0])
+		t.truthy(typeof r.url, 'string')
+		t.is(r.url.includes(item[0]), true)
+	})
+})
+
 test('File URL correctly parse the provider', async t => {
 	t.plan(fileDict.length)
 


### PR DESCRIPTION
I messed up what is returned from `mediaUrlParser()` here https://github.com/internet4000/media-url-parser/pull/7/files#diff-7a9076d6d94e62c13d641aa71f19ae8eR70

It should return an an object with an `url` string property. Instead it currently returns an `new URL` object. This fixes that. I also added a test so it doesn't happen again.

Fixes https://github.com/internet4000/radio4000/issues/293