### PR TITLE
add bandcamp parser, refactor naming, add type to parse answer

### DIFF
--- a/src/providers.js
+++ b/src/providers.js
@@ -1,7 +1,8 @@
 const providersList =  {
 	'youtube.com': 'youtube',
 	'youtu.be': 'youtube',
-	'discogs.com': 'discogs'
+	'discogs.com': 'discogs',
+	'bandcamp.com': 'bandcamp'
 }
 
 

--- a/test.js
+++ b/test.js
@@ -1,12 +1,18 @@
 import test from 'ava'
 import {mediaUrlParser} from './index.js'
-import {youtubeDict, fileDict, discogsDict} from './tests/provider-dictionaries'
+import {youtubeDict, fileDict, discogsDict, bandcampDict} from './tests/provider-dictionaries'
 
 /*
   Providers, check if they are correctly discovered in a url
 */
 
-test('Youtube URL correctly parse the provider', t => {
+test('It throws when it cannot detect a provider', t => {
+	const error = t.throws(() => {
+		mediaUrlParser('notanurl')
+	})
+})
+
+test('Youtube URL correctly parses the provider', t => {
 	t.plan(youtubeDict.length)
 
 	youtubeDict.forEach(item => {
@@ -15,7 +21,7 @@ test('Youtube URL correctly parse the provider', t => {
 	})
 })
 
-test('object returned includes a normalized url property', t => {
+test('Object returned includes a normalized url property', t => {
 	youtubeDict.forEach(item => {
 		let r = mediaUrlParser(item[0])
 		t.truthy(typeof r.url, 'string')
@@ -23,7 +29,7 @@ test('object returned includes a normalized url property', t => {
 	})
 })
 
-test('File URL correctly parse the provider', async t => {
+test('File URL correctly parses the provider', async t => {
 	t.plan(fileDict.length)
 
 	fileDict.forEach(item => {
@@ -32,7 +38,7 @@ test('File URL correctly parse the provider', async t => {
 	})
 })
 
-test('Discogs URL correctly parse the provider', async t => {
+test('Discogs URL correctly parses the provider', async t => {
 	t.plan(discogsDict.length)
 
 	discogsDict.forEach(item => {
@@ -41,11 +47,20 @@ test('Discogs URL correctly parse the provider', async t => {
 	})
 })
 
+test('Bandcamp URL correctly parses the provider', async t => {
+	t.plan(bandcampDict.length)
+
+	bandcampDict.forEach(item => {
+		let r = mediaUrlParser(item[0])
+		t.is(r.provider, 'bandcamp')
+	})
+})
+
 /*
   ID, check if the if is found in a url of a specific provider
 */
 
-test('Youtube URL correctly parse the id correctly', t => {
+test('Youtube URL correctly parses the id', t => {
 	t.plan(youtubeDict.length)
 
 	youtubeDict.forEach(item => {
@@ -54,7 +69,7 @@ test('Youtube URL correctly parse the id correctly', t => {
 	})
 })
 
-test('File URL correctly parse the id correctly', t => {
+test('File URL correctly parses the id', t => {
 	t.plan(fileDict.length)
 
 	fileDict.forEach(item => {
@@ -63,17 +78,33 @@ test('File URL correctly parse the id correctly', t => {
 	})
 })
 
-test('It throws when it cant detect a provider', t => {
-	const error = t.throws(() => {
-		mediaUrlParser('notanurl')
-	})
-})
-
-test('Discogs URL correctly parse the id correctly', t => {
+test('Discogs URL correctly parses the id', t => {
 	t.plan(discogsDict.length)
 
 	discogsDict.forEach(item => {
 		let r = mediaUrlParser(item[0])
 		t.is(r.id, item[1])
+	})
+})
+
+test('Bandcamp URL correctly parses the id ', t => {
+	t.plan(bandcampDict.length)
+
+	bandcampDict.forEach(item => {
+		let r = mediaUrlParser(item[0])
+		t.is(r.id, item[1])
+	})
+})
+
+/*
+  Type, check if the type is found in a url of a specific provider
+*/
+
+test('Bandcamp URL correctly parses the media type', async t => {
+	t.plan(bandcampDict.length)
+
+	bandcampDict.forEach(item => {
+		let r = mediaUrlParser(item[0])
+		t.is(r.type, item[2])
 	})
 })

--- a/tests/provider-dictionaries.js
+++ b/tests/provider-dictionaries.js
@@ -110,3 +110,16 @@ exports.discogsDict = [
 		'7983975'
 	]
 ]
+
+exports.bandcampDict = [
+	[
+		'https://iliantape.bandcamp.com/album/it039-andrea-forse',
+		'it039-andrea-forse',
+		'album'
+	],
+	[
+		'https://iliantape.bandcamp.com/track/future-atmo',
+		'future-atmo',
+		'track'
+	]
+]


### PR DESCRIPTION
Ref: https://github.com/internet4000/radio4000/issues/296

In this PR:

- refactor naming: it is more clear what the functions do, parse, [instead of just getting the id](https://github.com/internet4000/media-url-parser/pull/11/files#diff-7a9076d6d94e62c13d641aa71f19ae8eL18).
- type to parse answer: when a url is parsed, [it also give a type](https://github.com/internet4000/media-url-parser/pull/11/files#diff-7a9076d6d94e62c13d641aa71f19ae8eR24) to the media delivered by this specific provider. For now it is thought as respecting the naming offered by the provider, staying agnostic from media type uniformization (for now at least)
- [add bandcamp parser](https://github.com/internet4000/media-url-parser/pull/11/files#diff-7a9076d6d94e62c13d641aa71f19ae8eR43): pass a bandcamp `album` or `track` url and it will be parsed to give an id and a type.

```
{
  url: 'https://iliantape.bandcamp.com/album/it039-andrea-forse',
  provider: 'bandcamp',
  id: 'it039-andrea-forse',
  type: 'album'
}
{
  url: 'https://iliantape.bandcamp.com/track/future-atmo',
  provider: 'bandcamp',
  id: 'future-atmo',
  type: 'track'
}
```

Not sure what anyone will use that for, but at least it is there and is ready to be used to some applications.

Note: the same way we could add `soundcloud`, `spotify`, `vimeo` etc.