### PR TITLE
add soundcloud, but id is not really needed

### DIFF
--- a/main.js
+++ b/main.js
@@ -56,8 +56,13 @@ const findId = (url, provider) => {
 }
 
 const findProvider = (url) => {
-	let hostId = extractHostId(new URL(url).host)
-
+	let hostId;
+	try {
+		hostId = extractHostId(new URL(url).host)
+	} catch(error) {
+		console.error('Cannot find provider from url', url, error)
+	}
+	if(!hostId) return null
 	// from the hostId, find the provider id
 	// and fallback to file.
 	return providersList[hostId] || 'file'

--- a/main.js
+++ b/main.js
@@ -28,13 +28,24 @@ const vimeoUrlToId = (url) => {
 	// cool it works without the need of a custom parser!
   return fileUrlToId(url)
 }
+const soundcloudUrlToId = (url) => {
+	const getId = (url) => {
+		let result = new URL(url)
+		// remove first slash
+		let s = result.pathname.slice(1)
+		return s
+	}
+	const id = getId(url)
+	return id
+}
 
 const findId = (url, provider) => {
   let methods = {
 		youtube: (url) => youtubeUrlToId(url),
 		file: (url) => fileUrlToId(url),
 		discogs: (url) => discogsUrlToId(url),
-		vimeo: (url) => vimeoUrlToId(url)
+		vimeo: (url) => vimeoUrlToId(url),
+		soundcloud: (url) => soundcloudUrlToId(url)
   }
 	let extractId = methods[provider]
 	if (typeof extractId !== 'function') {

--- a/src/providers.js
+++ b/src/providers.js
@@ -2,7 +2,8 @@ const providersList =  {
 	'youtube.com': 'youtube',
 	'youtu.be': 'youtube',
 	'discogs.com': 'discogs',
-	'vimeo.com': 'vimeo'
+	'vimeo.com': 'vimeo',
+	'soundcloud.com': 'soundcloud'
 }
 
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,12 @@
 import test from 'ava'
 import {mediaUrlParser} from './index.js'
-import {youtubeDict, fileDict, discogsDict, vimeoDict} from './tests/provider-dictionaries'
+import {
+	youtubeDict,
+	fileDict,
+	discogsDict,
+	vimeoDict,
+	soundcloudDict
+} from './tests/provider-dictionaries'
 
 function testUrl(t, item, provider) {
 	let r = mediaUrlParser(item[0])
@@ -42,7 +48,7 @@ test('Youtube URL correctly parse the provider', t => {
 	})
 })
 
-test('Discogs URL correctly parse the id correctly', t => {
+test('Discogs URL correctly parse the id', t => {
 	t.plan(discogsDict.length * 2)
 
 	discogsDict.forEach(item => {
@@ -50,10 +56,18 @@ test('Discogs URL correctly parse the id correctly', t => {
 	})
 })
 
-test('Vimeo URL correctly parse the id correctly', t => {
+test('Vimeo URL correctly parse the id', t => {
 	t.plan(vimeoDict.length * 2)
 
 	vimeoDict.forEach(item => {
 		testUrl(t, item, 'vimeo')
+	})
+})
+
+test('Soundcloud URL correctly parse the id', t => {
+	t.plan(soundcloudDict.length * 2)
+
+	soundcloudDict.forEach(item => {
+		testUrl(t, item, 'soundcloud')
 	})
 })

--- a/test.js
+++ b/test.js
@@ -10,14 +10,14 @@ import {
 
 function testUrl(t, item, provider) {
 	let r = mediaUrlParser(item[0])
-	t.is(r.id, item[1])
 	t.is(r.provider, provider)
+	t.is(r.id, item[1])
 }
 
-test('It throws when it cant detect a provider', t => {
-	t.throws(() => {
-		testUrl(t, 'not-an-url', 'not a provider')
-	})
+test('It does not throw when it cant detect a provider', t => {
+	let r = mediaUrlParser('not-an-url')
+	t.is(r.provider, 'file')
+	t.is(r.id, null)
 })
 
 test('object returned includes a normalized url property', t => {

--- a/tests/provider-dictionaries.js
+++ b/tests/provider-dictionaries.js
@@ -133,3 +133,21 @@ exports.vimeoDict = [
 		'342770360'
 	]
 ]
+
+exports.soundcloudDict = [
+	[
+		'https://soundcloud.com/lyl_radio/sets/lyl-ra-at-dizonord',
+		'lyl_radio/sets/lyl-ra-at-dizonord',
+		'sets'
+	],
+	[
+		'https://soundcloud.com/lyl_radio/lyl-ra-at-dizonord-170519-w-dizonord-djs?in=lyl_radio/sets/lyl-ra-at-dizonord',
+		'lyl_radio/lyl-ra-at-dizonord-170519-w-dizonord-djs',
+		'track'
+	],
+	[
+		'https://soundcloud.com/lyl_radio/sur-ecoute-250419-w-pam-belec-danse-toujours-sainte-rita',
+		'lyl_radio/sur-ecoute-250419-w-pam-belec-danse-toujours-sainte-rita',
+		'track'
+	]
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2609,9 +2609,9 @@ resolve-url@^0.2.1:
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
 resolve@^1.10.0, resolve@^1.3.2:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
-  integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
+  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
trying things out!

soundcloud does not have real id in the url,
but still since it is kind of unique, we create one from the given path, without more check that a valid soundcloud.com host url.

as usuall, we're not making api calls here, so we can't get a soundcloud id. Which is not needed to play a soundcloud media! a soundcloud url is enough